### PR TITLE
feat: add delete_vault_activity MCP tool

### DIFF
--- a/cache/db.py
+++ b/cache/db.py
@@ -320,6 +320,16 @@ class CacheDB:
         except (ValueError, TypeError):
             return None
 
+    async def delete_activities(self, activity_ids: list[int]) -> int:
+        """Delete activities from the vault by ID. Returns number of rows deleted."""
+        placeholders = ",".join("?" * len(activity_ids))
+        cursor = await self._db.execute(
+            f"DELETE FROM activities WHERE id IN ({placeholders})",
+            activity_ids,
+        )
+        await self._db.commit()
+        return cursor.rowcount
+
     async def update_sync_log(self, total_synced: int, mode: str):
         """Record sync completion."""
         now = time.time()

--- a/formatters.py
+++ b/formatters.py
@@ -923,3 +923,13 @@ def format_vault_query(result: dict) -> str:
             lines.append(f"| {st} | {entry['count']} | {icon} |")
 
     return "\n".join(lines)
+
+
+def format_delete_activities(deleted: int, requested_ids: list[int]) -> str:
+    not_found = len(requested_ids) - deleted
+    lines = [f"## 🗑️ Delete Activities\n"]
+    lines.append(f"- **✅ Deleted:** {deleted}")
+    if not_found:
+        lines.append(f"- **⚠️ Not found:** {not_found} (already removed or invalid ID)")
+    lines.append(f"- **🏛️ IDs requested:** {', '.join(str(i) for i in requested_ids)}")
+    return "\n".join(lines)

--- a/server.py
+++ b/server.py
@@ -19,6 +19,7 @@ from formatters import (
     format_cache_stats,
     format_sync_result,
     format_vault_query,
+    format_delete_activities,
 )
 
 load_dotenv()
@@ -194,6 +195,20 @@ async def get_cache_stats() -> str:
     """Show cache hit/miss rates, stored items, and API rate limit status."""
     stats = await manager.get_cache_stats()
     return format_cache_stats(stats)
+
+
+@mcp.tool()
+async def delete_vault_activity(activity_ids: list[int]) -> str:
+    """Delete one or more activities from the local vault by Strava activity ID.
+
+    This only removes activities from the local database — it does not delete
+    them from Strava. Useful for removing duplicates or unwanted entries.
+
+    Args:
+        activity_ids: List of Strava activity IDs to delete (e.g. [12345, 67890]).
+    """
+    deleted = await manager.db.delete_activities(activity_ids)
+    return format_delete_activities(deleted, activity_ids)
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary

- Adds a `delete_vault_activity` MCP tool to remove one or more activities from the local vault by Strava activity ID
- Useful for cleaning up duplicates or unwanted entries without touching Strava itself
- Includes a `CacheDB.delete_activities()` method (batch DELETE by ID list) and a `format_delete_activities()` formatter that reports deleted/not-found counts

## Test plan

- [ ] Call `delete_vault_activity` with one or more valid IDs and confirm they are removed from the vault
- [ ] Call with an invalid/already-removed ID and confirm the not-found count is reported correctly
- [ ] Run `sync_activities` after deletion to confirm deleted activities are not re-added (incremental sync only fetches newer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)