### PR TITLE
Harden delete_vault_activity input handling

### DIFF
--- a/cache/db.py
+++ b/cache/db.py
@@ -320,6 +320,16 @@ class CacheDB:
         except (ValueError, TypeError):
             return None
 
+    async def delete_activities(self, activity_ids: list[int]) -> int:
+        """Delete activities from the vault by ID. Returns number of rows deleted."""
+        placeholders = ",".join("?" * len(activity_ids))
+        cursor = await self._db.execute(
+            f"DELETE FROM activities WHERE id IN ({placeholders})",
+            activity_ids,
+        )
+        await self._db.commit()
+        return cursor.rowcount
+
     async def update_sync_log(self, total_synced: int, mode: str):
         """Record sync completion."""
         now = time.time()

--- a/cache/db.py
+++ b/cache/db.py
@@ -322,6 +322,9 @@ class CacheDB:
 
     async def delete_activities(self, activity_ids: list[int]) -> int:
         """Delete activities from the vault by ID. Returns number of rows deleted."""
+        if not activity_ids:
+            return 0
+
         placeholders = ",".join("?" * len(activity_ids))
         cursor = await self._db.execute(
             f"DELETE FROM activities WHERE id IN ({placeholders})",

--- a/formatters.py
+++ b/formatters.py
@@ -923,3 +923,13 @@ def format_vault_query(result: dict) -> str:
             lines.append(f"| {st} | {entry['count']} | {icon} |")
 
     return "\n".join(lines)
+
+
+def format_delete_activities(deleted: int, requested_ids: list[int]) -> str:
+    not_found = len(requested_ids) - deleted
+    lines = [f"## 🗑️ Delete Activities\n"]
+    lines.append(f"- **✅ Deleted:** {deleted}")
+    if not_found:
+        lines.append(f"- **⚠️ Not found:** {not_found} (already removed or invalid ID)")
+    lines.append(f"- **🏛️ IDs requested:** {', '.join(str(i) for i in requested_ids)}")
+    return "\n".join(lines)

--- a/formatters.py
+++ b/formatters.py
@@ -926,6 +926,9 @@ def format_vault_query(result: dict) -> str:
 
 
 def format_delete_activities(deleted: int, requested_ids: list[int]) -> str:
+    if not requested_ids:
+        return "## 🗑️ Delete Activities\n\n- No IDs provided."
+
     not_found = len(requested_ids) - deleted
     lines = [f"## 🗑️ Delete Activities\n"]
     lines.append(f"- **✅ Deleted:** {deleted}")

--- a/server.py
+++ b/server.py
@@ -19,6 +19,7 @@ from formatters import (
     format_cache_stats,
     format_sync_result,
     format_vault_query,
+    format_delete_activities,
 )
 
 load_dotenv()
@@ -194,6 +195,20 @@ async def get_cache_stats() -> str:
     """Show cache hit/miss rates, stored items, and API rate limit status."""
     stats = await manager.get_cache_stats()
     return format_cache_stats(stats)
+
+
+@mcp.tool()
+async def delete_vault_activity(activity_ids: list[int]) -> str:
+    """Delete one or more activities from the local vault by Strava activity ID.
+
+    This only removes activities from the local database — it does not delete
+    them from Strava. Useful for removing duplicates or unwanted entries.
+
+    Args:
+        activity_ids: List of Strava activity IDs to delete (e.g. [12345, 67890]).
+    """
+    deleted = await manager.db.delete_activities(activity_ids)
+    return format_delete_activities(deleted, activity_ids)
 
 
 @mcp.tool()

--- a/server.py
+++ b/server.py
@@ -207,6 +207,9 @@ async def delete_vault_activity(activity_ids: list[int]) -> str:
     Args:
         activity_ids: List of Strava activity IDs to delete (e.g. [12345, 67890]).
     """
+    if not activity_ids:
+        return "No activity IDs provided. Pass one or more IDs, e.g. [12345]."
+
     deleted = await manager.db.delete_activities(activity_ids)
     return format_delete_activities(deleted, activity_ids)
 

--- a/tests/test_delete_guard.py
+++ b/tests/test_delete_guard.py
@@ -1,0 +1,14 @@
+from formatters import format_delete_activities
+
+def test_formatter_handles_empty_ids():
+    out = format_delete_activities(0, [])
+    assert "No IDs provided" in out
+
+def test_formatter_counts_not_found():
+    out = format_delete_activities(1, [1,2,3])
+    assert "Deleted" in out and "Not found" in out
+
+if __name__ == '__main__':
+    test_formatter_handles_empty_ids()
+    test_formatter_counts_not_found()
+    print('PASS: delete guard tests')


### PR DESCRIPTION
Follow-up hardening for #4.

## Changes
- Guard empty `activity_ids` in delete path to avoid invalid SQL `IN ()`
- Return clear message when no IDs are provided
- Add formatter guard for empty list
- Add regression test: `tests/test_delete_guard.py`

This does not merge #4 directly, but provides a safe patch branch you can cherry-pick or merge after review.
