### PR TITLE
Harden nearby activity search input validation

### DIFF
--- a/cache/db.py
+++ b/cache/db.py
@@ -68,8 +68,8 @@ class CacheDB:
         """)
         await self._db.commit()
 
-        # Migration: add lat/lon columns if not present, then backfill from stored JSON
-        for col in ("start_lat REAL", "start_lon REAL"):
+        # Migration: add lat/lon and location_override columns if not present
+        for col in ("start_lat REAL", "start_lon REAL", "location_override TEXT"):
             try:
                 await self._db.execute(f"ALTER TABLE activities ADD COLUMN {col}")
             except Exception:
@@ -362,19 +362,30 @@ class CacheDB:
 
         where = f"WHERE {' AND '.join(conditions)}"
         cursor = await self._db.execute(
-            f"SELECT data, start_lat, start_lon FROM activities {where} ORDER BY start_date DESC",
+            f"SELECT data, start_lat, start_lon, location_override FROM activities {where} ORDER BY start_date DESC",
             params,
         )
         rows = await cursor.fetchall()
 
         results = []
-        for data, a_lat, a_lon in rows:
+        for data, a_lat, a_lon, loc_override in rows:
             d = _haversine_miles(a_lat, a_lon, lat, lon)
             if d <= radius_miles:
                 activity = json.loads(data)
                 activity["_distance_from_query_miles"] = round(d, 1)
+                if loc_override:
+                    activity["_location_override"] = loc_override
                 results.append(activity)
         return results
+
+    async def set_location_override(self, activity_id: int, location: str | None) -> bool:
+        """Set (or clear) a manual location string for an activity. Returns True if found."""
+        cursor = await self._db.execute(
+            "UPDATE activities SET location_override = ? WHERE id = ?",
+            (location, activity_id),
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
 
     async def get_vault_date_range(self) -> dict | None:
         """Return the earliest and latest activity dates in the vault."""

--- a/cache/db.py
+++ b/cache/db.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 import time
 from datetime import datetime
@@ -6,6 +7,14 @@ from datetime import datetime
 import aiosqlite
 
 from cache.encryption import encrypt_token, decrypt_token
+
+
+def _haversine_miles(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    R = 3958.8
+    dlat = math.radians(lat2 - lat1)
+    dlon = math.radians(lon2 - lon1)
+    a = math.sin(dlat / 2) ** 2 + math.cos(math.radians(lat1)) * math.cos(math.radians(lat2)) * math.sin(dlon / 2) ** 2
+    return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
 
 
 class CacheDB:
@@ -58,6 +67,21 @@ class CacheDB:
             );
         """)
         await self._db.commit()
+
+        # Migration: add lat/lon columns if not present, then backfill from stored JSON
+        for col in ("start_lat REAL", "start_lon REAL"):
+            try:
+                await self._db.execute(f"ALTER TABLE activities ADD COLUMN {col}")
+            except Exception:
+                pass  # already exists
+        await self._db.execute("""
+            UPDATE activities
+            SET start_lat = json_extract(data, '$.start_latlng[0]'),
+                start_lon = json_extract(data, '$.start_latlng[1]')
+            WHERE start_lat IS NULL
+        """)
+        await self._db.commit()
+
         await self.cleanup_expired()
 
     async def get_cached(self, key: str) -> dict | None:
@@ -168,18 +192,29 @@ class CacheDB:
 
     # ── Vault (permanent activity storage) ────────────────────────────
 
+    @staticmethod
+    def _extract_latlng(activity: dict) -> tuple[float | None, float | None]:
+        coords = activity.get("start_latlng") or []
+        if len(coords) == 2:
+            return coords[0], coords[1]
+        return None, None
+
     async def upsert_activity(self, activity: dict):
         """Store or update a single activity in the vault."""
         now = time.time()
+        lat, lon = self._extract_latlng(activity)
         await self._db.execute(
-            "INSERT OR REPLACE INTO activities (id, data, start_date, start_date_local, sport_type, synced_at) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT OR REPLACE INTO activities "
+            "(id, data, start_date, start_date_local, sport_type, start_lat, start_lon, synced_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 activity["id"],
                 json.dumps(activity),
                 activity.get("start_date"),
                 activity.get("start_date_local"),
                 activity.get("sport_type") or activity.get("type"),
+                lat,
+                lon,
                 now,
             ),
         )
@@ -194,13 +229,15 @@ class CacheDB:
                 a.get("start_date"),
                 a.get("start_date_local"),
                 a.get("sport_type") or a.get("type"),
+                *self._extract_latlng(a),
                 now,
             )
             for a in activities
         ]
         await self._db.executemany(
-            "INSERT OR REPLACE INTO activities (id, data, start_date, start_date_local, sport_type, synced_at) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT OR REPLACE INTO activities "
+            "(id, data, start_date, start_date_local, sport_type, start_lat, start_lon, synced_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             rows,
         )
         await self._db.commit()
@@ -291,6 +328,53 @@ class CacheDB:
         )
         rows = await cursor.fetchall()
         return [{"sport_type": row[0], "count": row[1]} for row in rows]
+
+    async def get_activities_near_location(
+        self,
+        lat: float,
+        lon: float,
+        radius_miles: float = 20.0,
+        sport_type: str | None = None,
+        after: str | None = None,
+        before: str | None = None,
+    ) -> list[dict]:
+        """Return activities that started within radius_miles of (lat, lon)."""
+        # Bounding box pre-filter in SQL, then precise haversine in Python
+        lat_delta = radius_miles / 69.0
+        lon_delta = radius_miles / (69.0 * math.cos(math.radians(lat)))
+
+        conditions = [
+            "start_lat IS NOT NULL",
+            "start_lat BETWEEN ? AND ?",
+            "start_lon BETWEEN ? AND ?",
+        ]
+        params: list = [lat - lat_delta, lat + lat_delta, lon - lon_delta, lon + lon_delta]
+
+        if sport_type:
+            conditions.append("sport_type = ?")
+            params.append(sport_type)
+        if after:
+            conditions.append("start_date_local >= ?")
+            params.append(after)
+        if before:
+            conditions.append("start_date_local < ?")
+            params.append(before)
+
+        where = f"WHERE {' AND '.join(conditions)}"
+        cursor = await self._db.execute(
+            f"SELECT data, start_lat, start_lon FROM activities {where} ORDER BY start_date DESC",
+            params,
+        )
+        rows = await cursor.fetchall()
+
+        results = []
+        for data, a_lat, a_lon in rows:
+            d = _haversine_miles(a_lat, a_lon, lat, lon)
+            if d <= radius_miles:
+                activity = json.loads(data)
+                activity["_distance_from_query_miles"] = round(d, 1)
+                results.append(activity)
+        return results
 
     async def get_vault_date_range(self) -> dict | None:
         """Return the earliest and latest activity dates in the vault."""

--- a/cache/geocode.py
+++ b/cache/geocode.py
@@ -1,0 +1,24 @@
+"""Nominatim geocoding helpers (forward only — no API key required)."""
+
+import asyncio
+import json
+import urllib.parse
+import urllib.request
+
+_USER_AGENT = "strava-mcp-vault/1.0"
+_BASE = "https://nominatim.openstreetmap.org"
+
+
+def _get(url: str) -> dict | list:
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    with urllib.request.urlopen(req, timeout=8) as r:
+        return json.loads(r.read())
+
+
+async def forward_geocode(place: str) -> tuple[float, float] | None:
+    """Resolve a place name to (lat, lon). Returns None if not found."""
+    url = f"{_BASE}/search?q={urllib.parse.quote(place)}&format=json&limit=1"
+    result = await asyncio.to_thread(_get, url)
+    if not result:
+        return None
+    return float(result[0]["lat"]), float(result[0]["lon"])

--- a/cache/geocode.py
+++ b/cache/geocode.py
@@ -1,18 +1,27 @@
-"""Nominatim geocoding helpers (forward only — no API key required)."""
+"""Nominatim geocoding helpers (forward + reverse — no API key required)."""
 
 import asyncio
 import json
+import time
 import urllib.parse
 import urllib.request
 
 _USER_AGENT = "strava-mcp-vault/1.0"
 _BASE = "https://nominatim.openstreetmap.org"
+_last_request_time: float = 0.0
 
 
 def _get(url: str) -> dict | list:
+    global _last_request_time
+    # Nominatim requires max 1 request/second
+    elapsed = time.monotonic() - _last_request_time
+    if elapsed < 1.0:
+        time.sleep(1.0 - elapsed)
     req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
     with urllib.request.urlopen(req, timeout=8) as r:
-        return json.loads(r.read())
+        result = json.loads(r.read())
+    _last_request_time = time.monotonic()
+    return result
 
 
 async def forward_geocode(place: str) -> tuple[float, float] | None:
@@ -22,3 +31,45 @@ async def forward_geocode(place: str) -> tuple[float, float] | None:
     if not result:
         return None
     return float(result[0]["lat"]), float(result[0]["lon"])
+
+
+async def reverse_geocode_many(
+    coords: list[tuple[float, float]],
+) -> dict[tuple[float, float], str]:
+    """Reverse geocode a list of (lat, lon) pairs.
+
+    Deduplicates by rounding to 2 decimal places (~1 km), so nearby
+    activities only trigger one request. Returns a dict mapping each
+    original (lat, lon) to a 'City, State' string.
+    """
+    def _city_state(addr: dict) -> str:
+        city = (
+            addr.get("city")
+            or addr.get("town")
+            or addr.get("village")
+            or addr.get("hamlet")
+            or ""
+        )
+        state = addr.get("state", "")
+        return f"{city}, {state}" if city else state
+
+    def _fetch_one(lat: float, lon: float) -> str:
+        url = f"{_BASE}/reverse?lat={lat}&lon={lon}&format=json"
+        try:
+            data = _get(url)
+            return _city_state(data.get("address", {}))
+        except Exception:
+            return ""
+
+    # Build unique rounded keys
+    rounded: dict[tuple[float, float], tuple[float, float]] = {}
+    for lat, lon in coords:
+        key = (round(lat, 2), round(lon, 2))
+        rounded[(lat, lon)] = key
+
+    unique_keys = list({v for v in rounded.values()})
+    cache: dict[tuple[float, float], str] = {}
+    for key in unique_keys:
+        cache[key] = await asyncio.to_thread(_fetch_one, *key)
+
+    return {orig: cache[rounded[orig]] for orig in coords}

--- a/formatters.py
+++ b/formatters.py
@@ -935,8 +935,8 @@ def format_activities_near(
 
     lines = [f"## 📍 Activities Near {place} ({radius_miles:.0f} mi radius)\n"]
     lines.append(f"**{len(activities)} activities found**\n")
-    lines.append("| Date | Type | Distance | Time | From Center | Name |")
-    lines.append("|------|------|----------|------|-------------|------|")
+    lines.append("| Date | Type | Distance | Time | Location | From Center | Name |")
+    lines.append("|------|------|----------|------|----------|-------------|------|")
 
     for a in activities:
         date = (a.get("start_date_local") or "")[:10]
@@ -946,8 +946,9 @@ def format_activities_near(
         t = a.get("moving_time", 0)
         h, m = divmod(t // 60, 60)
         time_str = f"{h}:{m:02d}"
+        location = a.get("_location") or "—"
         near = a.get("_distance_from_query_miles", "?")
         name = a.get("name") or "—"
-        lines.append(f"| {date} | {icon} {sport} | {dist_mi:.1f} mi | {time_str} | {near} mi | {name} |")
+        lines.append(f"| {date} | {icon} {sport} | {dist_mi:.1f} mi | {time_str} | {location} | {near} mi | {name} |")
 
     return "\n".join(lines)

--- a/formatters.py
+++ b/formatters.py
@@ -923,3 +923,31 @@ def format_vault_query(result: dict) -> str:
             lines.append(f"| {st} | {entry['count']} | {icon} |")
 
     return "\n".join(lines)
+
+
+def format_activities_near(
+    activities: list[dict],
+    place: str,
+    radius_miles: float,
+) -> str:
+    if not activities:
+        return f"## 📍 Activities Near {place}\n\nNo activities found within {radius_miles:.0f} miles."
+
+    lines = [f"## 📍 Activities Near {place} ({radius_miles:.0f} mi radius)\n"]
+    lines.append(f"**{len(activities)} activities found**\n")
+    lines.append("| Date | Type | Distance | Time | From Center | Name |")
+    lines.append("|------|------|----------|------|-------------|------|")
+
+    for a in activities:
+        date = (a.get("start_date_local") or "")[:10]
+        sport = a.get("sport_type") or a.get("type") or "?"
+        icon = _sport_icon(sport)
+        dist_mi = a.get("distance", 0) / METERS_PER_MILE
+        t = a.get("moving_time", 0)
+        h, m = divmod(t // 60, 60)
+        time_str = f"{h}:{m:02d}"
+        near = a.get("_distance_from_query_miles", "?")
+        name = a.get("name") or "—"
+        lines.append(f"| {date} | {icon} {sport} | {dist_mi:.1f} mi | {time_str} | {near} mi | {name} |")
+
+    return "\n".join(lines)

--- a/server.py
+++ b/server.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 
 from cache.db import CacheDB
-from cache.geocode import forward_geocode
+from cache.geocode import forward_geocode, reverse_geocode_many
 from cache.manager import CacheManager
 from clients.strava import StravaClient, RateLimitError
 from formatters import (
@@ -226,6 +226,16 @@ async def get_activities_near(
         lat, lon, radius_miles=radius_miles,
         sport_type=sport_type, after=after, before=before,
     )
+    if results:
+        activity_coords = [
+            (a["start_latlng"][0], a["start_latlng"][1])
+            for a in results
+            if a.get("start_latlng") and len(a["start_latlng"]) == 2
+        ]
+        location_map = await reverse_geocode_many(activity_coords)
+        for a in results:
+            coords_key = tuple(a["start_latlng"][:2]) if a.get("start_latlng") else None
+            a["_location"] = location_map.get(coords_key, "") if coords_key else ""
     return format_activities_near(results, location, radius_miles)
 
 

--- a/server.py
+++ b/server.py
@@ -191,6 +191,15 @@ async def get_athlete_stats() -> str:
         return str(e)
 
 
+
+
+def _validate_radius_miles(radius_miles: float) -> str | None:
+    if radius_miles <= 0:
+        return "radius_miles must be greater than 0."
+    if radius_miles > 250:
+        return "radius_miles is too large. Use 250 miles or less."
+    return None
+
 @mcp.tool()
 async def get_cache_stats() -> str:
     """Show cache hit/miss rates, stored items, and API rate limit status."""
@@ -218,6 +227,14 @@ async def get_activities_near(
         after: Only activities on or after this date (ISO format, e.g. "2025-01-01").
         before: Only activities before this date (ISO format, e.g. "2026-01-01").
     """
+    location = (location or "").strip()
+    if not location:
+        return "Location is required. Example: 'Syracuse, NY'."
+
+    radius_error = _validate_radius_miles(radius_miles)
+    if radius_error:
+        return radius_error
+
     coords = await forward_geocode(location)
     if coords is None:
         return f"Could not geocode '{location}'. Try a more specific place name."

--- a/server.py
+++ b/server.py
@@ -7,6 +7,7 @@ from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 
 from cache.db import CacheDB
+from cache.geocode import forward_geocode
 from cache.manager import CacheManager
 from clients.strava import StravaClient, RateLimitError
 from formatters import (
@@ -19,6 +20,7 @@ from formatters import (
     format_cache_stats,
     format_sync_result,
     format_vault_query,
+    format_activities_near,
 )
 
 load_dotenv()
@@ -194,6 +196,37 @@ async def get_cache_stats() -> str:
     """Show cache hit/miss rates, stored items, and API rate limit status."""
     stats = await manager.get_cache_stats()
     return format_cache_stats(stats)
+
+
+@mcp.tool()
+async def get_activities_near(
+    location: str,
+    radius_miles: float = 20.0,
+    sport_type: str | None = None,
+    after: str | None = None,
+    before: str | None = None,
+) -> str:
+    """Find vault activities that started near a given location.
+
+    Geocodes the location name, then searches the local vault for activities
+    that started within the specified radius. No Strava API calls are made.
+
+    Args:
+        location: Place name to search near (e.g. "Syracuse, NY", "Central Park").
+        radius_miles: Search radius in miles (default 20).
+        sport_type: Filter by activity type (e.g. "Ride", "Run", "GravelRide").
+        after: Only activities on or after this date (ISO format, e.g. "2025-01-01").
+        before: Only activities before this date (ISO format, e.g. "2026-01-01").
+    """
+    coords = await forward_geocode(location)
+    if coords is None:
+        return f"Could not geocode '{location}'. Try a more specific place name."
+    lat, lon = coords
+    results = await manager.db.get_activities_near_location(
+        lat, lon, radius_miles=radius_miles,
+        sport_type=sport_type, after=after, before=before,
+    )
+    return format_activities_near(results, location, radius_miles)
 
 
 @mcp.tool()

--- a/server.py
+++ b/server.py
@@ -234,9 +234,31 @@ async def get_activities_near(
         ]
         location_map = await reverse_geocode_many(activity_coords)
         for a in results:
-            coords_key = tuple(a["start_latlng"][:2]) if a.get("start_latlng") else None
-            a["_location"] = location_map.get(coords_key, "") if coords_key else ""
+            if a.get("_location_override"):
+                a["_location"] = a["_location_override"]
+            else:
+                coords_key = tuple(a["start_latlng"][:2]) if a.get("start_latlng") else None
+                a["_location"] = location_map.get(coords_key, "") if coords_key else ""
     return format_activities_near(results, location, radius_miles)
+
+
+@mcp.tool()
+async def set_activity_location(activity_id: int, location: str | None = None) -> str:
+    """Manually set (or clear) the display location for a vault activity.
+
+    Useful for activities recorded indoors or without GPS where no location
+    can be reverse geocoded. Pass location=None to clear an override.
+
+    Args:
+        activity_id: The Strava activity ID to update.
+        location: Location string to display (e.g. "Ithaca, NY"). Pass null to clear.
+    """
+    found = await manager.db.set_location_override(activity_id, location)
+    if not found:
+        return f"Activity {activity_id} not found in vault."
+    if location:
+        return f"✅ Location for activity {activity_id} set to \"{location}\"."
+    return f"✅ Location override cleared for activity {activity_id}."
 
 
 @mcp.tool()

--- a/tests/test_get_activities_near_validation.py
+++ b/tests/test_get_activities_near_validation.py
@@ -1,0 +1,12 @@
+from server import _validate_radius_miles
+
+
+def test_radius_validation_bounds():
+    assert _validate_radius_miles(20.0) is None
+    assert "greater than 0" in _validate_radius_miles(0)
+    assert "greater than 0" in _validate_radius_miles(-5)
+    assert "250 miles" in _validate_radius_miles(300)
+
+if __name__ == "__main__":
+    test_radius_validation_bounds()
+    print("PASS: get_activities_near validation")


### PR DESCRIPTION
Follow-up hardening for #5.

## Changes
- Validate `location` input is non-empty before geocoding
- Add radius bounds validation (`> 0` and `<= 250` miles)
- Add regression test: `tests/test_get_activities_near_validation.py`

Notes:
- Test run in local venv: PASS
- This is a safe follow-up branch and does not auto-merge #5.
