### PR TITLE
fix(deps): bump cryptography to 50.0.0 (CVE-2026-69247)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ httpx==0.28.1
 aiosqlite==0.22.1
 python-dotenv==1.2.2
 uvicorn==0.52.1
-cryptography==49.0.0
+cryptography==50.0.0


### PR DESCRIPTION
Resolves both open high-severity Dependabot alerts (CVE-2026-69247, Bleichenbacher oracle in PKCS#7 EnvelopedData decryption). Fix version is 50.0.0.

This is a major-version bump, so it sat outside the `python-minor-patch` group in `.github/dependabot.yml` and Dependabot never opened a PR for it. Pinned in `requirements.txt`.

Only `cryptography.fernet.Fernet` is used in this codebase (`cache/encryption.py`), which is unchanged across the 49 to 50 boundary. Relying on CI to confirm.