### PR TITLE
fix(deps): migrate to MCPServer for mcp 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mcp[cli]==1.28.1
+mcp[cli]==2.0.0
 httpx==0.28.1
 aiosqlite==0.22.1
 python-dotenv==1.2.2

--- a/server.py
+++ b/server.py
@@ -4,7 +4,7 @@ import sys
 from contextlib import asynccontextmanager
 
 from dotenv import load_dotenv
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from cache.db import CacheDB
 from cache.geocode import forward_geocode, reverse_geocode_many
@@ -87,7 +87,12 @@ async def lifespan(server):
 
 
 port = int(os.getenv("STRAVA_MCP_PORT", "18201"))
-mcp = FastMCP("strava-vault", host="0.0.0.0", port=port, lifespan=lifespan)
+
+# Bind address for the HTTP transport. This value is load-bearing twice over:
+# once for uvicorn, and once for MCP transport security (see build_app).
+HTTP_HOST = "0.0.0.0"
+
+mcp = MCPServer("strava-vault", lifespan=lifespan)
 
 
 @mcp.tool()
@@ -350,15 +355,30 @@ async def sync_activities(days_back: int = 0) -> str:
         return f"Unexpected error: {type(e).__name__}: {e}"
 
 
+def build_app():
+    """Build the Streamable HTTP ASGI app, with bearer auth if configured.
+
+    Streamable HTTP transport (MCP spec 2025-06-18). Replaces the deprecated
+    HTTP+SSE transport from 2024-11-05. Single /mcp endpoint that serves POST
+    (client -> server) and GET (server -> client SSE stream) on the same path.
+
+    Passing host=HTTP_HOST is REQUIRED, not redundant with the uvicorn bind
+    below. Since mcp 2.0, streamable_http_app() auto-enables DNS-rebinding
+    protection whenever it is given a loopback host (its default is
+    "127.0.0.1"), which makes the server answer HTTP 421 "Invalid Host header"
+    to every request that does not arrive as localhost. This server is reached
+    over the LAN and Tailscale, so that would break every real client while
+    still looking healthy from the box itself.
+
+    Do not "simplify" this to streamable_http_app().
+    See tests/test_transport_host.py, which fails if this argument is dropped.
+    """
+    from auth import maybe_add_auth
+
+    return maybe_add_auth(mcp.streamable_http_app(host=HTTP_HOST))
+
+
 if __name__ == "__main__":
     import uvicorn
 
-    from auth import maybe_add_auth
-
-    # Streamable HTTP transport (MCP spec 2025-06-18). Replaces the
-    # deprecated HTTP+SSE transport from 2024-11-05. Single /mcp endpoint
-    # that serves POST (client -> server) and GET (server -> client SSE
-    # stream) on the same path.
-    app = mcp.streamable_http_app()
-    app = maybe_add_auth(app)
-    uvicorn.run(app, host="0.0.0.0", port=port)
+    uvicorn.run(build_app(), host=HTTP_HOST, port=port)

--- a/tests/test_transport_host.py
+++ b/tests/test_transport_host.py
@@ -1,0 +1,99 @@
+"""Regression tests for the Streamable HTTP transport bind host.
+
+Since mcp 2.0, MCPServer.streamable_http_app() auto-enables DNS-rebinding
+protection whenever it is called with a loopback host, and its default host
+is "127.0.0.1". Under that protection the server answers HTTP 421
+"Invalid Host header" to any request whose Host header is not localhost.
+
+strava-mcp-vault is reached over the LAN and Tailscale, so dropping the
+explicit non-loopback host would break every real client while the unit
+suite stayed green and a localhost healthcheck kept passing. These tests
+exist so that regression cannot happen silently.
+"""
+
+import ipaddress
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+# The real deployment target. If a LAN client with this Host header cannot
+# talk to the server, the deployment is broken.
+DEPLOY_HOST_HEADER = "192.168.86.20:18201"
+
+INITIALIZE_REQUEST = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2025-06-18",
+        "capabilities": {},
+        "clientInfo": {"name": "regression-test", "version": "1.0"},
+    },
+}
+
+MCP_HEADERS = {
+    "Host": DEPLOY_HOST_HEADER,
+    "Origin": f"http://{DEPLOY_HOST_HEADER}",
+    "Content-Type": "application/json",
+    "Accept": "application/json, text/event-stream",
+}
+
+# The exact set mcp 2.0 treats as loopback when deciding whether to
+# auto-enable DNS-rebinding protection.
+SDK_LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "::1")
+
+
+@pytest.fixture(autouse=True)
+def _no_auth_token(monkeypatch):
+    """Keep bearer auth out of the way; these tests are about transport."""
+    monkeypatch.delenv("MCP_AUTH_TOKEN", raising=False)
+
+
+def _post_initialize(app):
+    """Drive one initialize request through the app's real ASGI lifespan.
+
+    _startup() is stubbed out: it wants live Strava credentials and a database,
+    and none of that is what these tests are checking.
+    """
+    with patch("server._startup", AsyncMock()), TestClient(app) as client:
+        return client.post("/mcp", headers=MCP_HEADERS, json=INITIALIZE_REQUEST)
+
+
+def test_http_host_is_not_loopback():
+    """The configured bind host must not trip the SDK's loopback check."""
+    from server import HTTP_HOST
+
+    assert HTTP_HOST not in SDK_LOOPBACK_HOSTS
+    assert not ipaddress.ip_address(HTTP_HOST).is_loopback
+
+
+def test_lan_client_is_not_rejected():
+    """A LAN-style Host header must get a real MCP response, not a 421."""
+    from server import build_app
+
+    response = _post_initialize(build_app())
+
+    assert response.status_code != 421, (
+        "Server rejected a LAN Host header with 'Invalid Host header'. "
+        "streamable_http_app() was most likely called without an explicit "
+        "non-loopback host, so mcp auto-enabled DNS-rebinding protection."
+    )
+    assert response.status_code == 200
+    assert "protocolVersion" in response.text
+
+
+def test_loopback_default_would_reject_lan_client():
+    """Positive control: prove the test above can detect the failure mode.
+
+    This builds the app the way a well-meaning "cleanup" commit would (letting
+    the host default to loopback) and asserts it produces exactly the 421 that
+    test_lan_client_is_not_rejected guards against. If this test ever stops
+    failing that way, the guard above has gone blind and needs rewriting.
+    """
+    from server import mcp
+
+    response = _post_initialize(mcp.streamable_http_app())
+
+    assert response.status_code == 421
+    assert "Invalid Host header" in response.text


### PR DESCRIPTION
Unblocks #35. `mcp` 2.0.0 removes `mcp.server.fastmcp`, so that bump currently fails the `test` job at pytest collection.

## Migration target

The successor ships inside the SDK, so this does not add a dependency. From the [v2.0.0 release notes](https://github.com/modelcontextprotocol/python-sdk/releases): *"`FastMCP` is now `MCPServer`... The decorator API is unchanged."* Verified against a real 2.0.0 install rather than from docs alone: `mcp.server.fastmcp` is gone, `from mcp.server import MCPServer` is the replacement, and `@mcp.tool()` still returns the original function object, so all 11 tool bodies and every existing test carry over untouched.

Standalone `fastmcp` was considered and rejected: it would layer a package on top of `mcp` to replace something `mcp` now provides natively, for a server that uses only the plain decorator API.

## The part worth reviewing

`MCPServer` drops `host` and `port` from its constructor. `port` only ever fed uvicorn, but `host` is a real behavior change. Since 2.0, `streamable_http_app()` auto-enables DNS-rebinding protection whenever it is handed a loopback host, and its default is now `127.0.0.1`:

```python
if transport_security is None and host in ("127.0.0.1", "localhost", "::1"):
    transport_security = TransportSecuritySettings(enable_dns_rebinding_protection=True, ...)
```

1.28.1 had no such auto-enable. Ported naively, this server would answer **HTTP 421 "Invalid Host header"** to every client that is not localhost, taking down the LAN and Tailscale endpoints. It would also do so silently: all tests pass, CI goes green, and a localhost healthcheck from inside the container keeps reporting healthy. Passing `host="0.0.0.0"` explicitly restores 1.x behavior.

## Changes

- `server.py`: `FastMCP` -> `MCPServer`; bind host lifted to an `HTTP_HOST` constant; `build_app()` extracted so the transport wiring is reachable from tests, with a comment explaining why the `host=` argument is load-bearing and must not be tidied away.
- `requirements.txt`: `mcp[cli]` 1.28.1 -> 2.0.0.
- `tests/test_transport_host.py`: new. Asserts the bind host is not loopback, asserts a LAN-style `Host: 192.168.86.20:18201` gets a real response instead of a 421, and includes a positive control that builds the app the loopback way and asserts it *does* 421 — so the guard cannot quietly go blind.

## Verification

- 149 tests pass (146 existing + 3 new), coverage 83.5% against the 70% floor.
- Mutation-tested the guard: dropping `host=` fails `test_lan_client_is_not_rejected`; setting `HTTP_HOST = "127.0.0.1"` fails that plus `test_http_host_is_not_loopback`. The test earns its place.
- Live uvicorn smoke on the real `build_app()`: LAN Host header with no bearer token -> 401 from the existing auth middleware; with a valid token -> 200 and a full `initialize` result. Tool list and a `get_cache_stats` call both verified over Streamable HTTP.
- A 2025-06-18 protocol client still negotiates fine against the v2 server.

**CI is the Python 3.13 check.** Everything above was validated locally on 3.13's successor, 3.14, which is what was on hand; the workflow pins 3.13. `ruff check` and `ruff format --check` both clean under the CI-pinned ruff 0.11.6.

Not deployed to nix1. The container will need a rebuild and restart on merge, which is a separate call.