### PR TITLE
ci: publish to GHCR on tag instead of building on the host

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,113 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build + Push image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Verify docker-compose.yml points at the version being released
+        # This repo has no [project] version in pyproject.toml, so the pinned
+        # tag in docker-compose.yml is the only version surface. If it does not
+        # match the git tag, nix1 would pull an image this release never built.
+        # Fail closed: GHCR tags are cheap to re-push, a wrong compose is not.
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet pyyaml
+          python3 - <<'PYEOF'
+          import os
+          import sys
+
+          import yaml
+
+          version = os.environ["REF_NAME"].removeprefix("v")
+          expected = f"ghcr.io/{os.environ['GITHUB_REPOSITORY'].lower()}:{version}"
+
+          # Parse the YAML key rather than grepping the file: the surrounding
+          # comments also contain an image reference, and a text search would
+          # happily match a stale one and pass.
+          with open("docker-compose.yml") as fh:
+              compose = yaml.safe_load(fh)
+
+          actual = compose["services"]["strava-mcp-vault"].get("image")
+          if actual != expected:
+              print(f"::error::docker-compose.yml pins '{actual}', expected '{expected}'")
+              print("::error::Bump the compose image tag in a commit BEFORE cutting the tag.")
+              sys.exit(1)
+
+          print(f"  ok  docker-compose.yml pins {actual}")
+          PYEOF
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+  github-release:
+    name: GitHub release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -230,6 +230,51 @@ python server.py
 
 Requires Python 3.13+.
 
+## Releasing and deploying
+
+The image is published to GHCR by CI, not built on the host. `docker-compose.yml`
+pins an explicit version so a restart can never silently change the running code.
+
+To cut a release:
+
+1. Bump the image tag in `docker-compose.yml` to the new version and commit it.
+   The release workflow refuses to publish if this disagrees with the git tag,
+   which stops a release from producing an image the compose does not reference.
+2. Tag and push:
+
+   ```bash
+   git tag -a v0.3.0 -m "v0.3.0"
+   git push origin v0.3.0
+   ```
+
+3. `.github/workflows/release.yml` builds `linux/amd64` and `linux/arm64`,
+   pushes to `ghcr.io/pete-builds/strava-mcp-vault`, attaches an SBOM and a
+   signed provenance attestation, and cuts a GitHub release.
+
+4. On the host:
+
+   ```bash
+   docker compose pull && docker compose up -d
+   ```
+
+### Verify the deploy, do not trust a green pipeline
+
+This server binds a non-loopback host on purpose. The MCP SDK enables
+DNS-rebinding protection automatically when the bind host is loopback, which
+makes the server answer `HTTP 421 Invalid Host header` to every LAN client
+while every unit test still passes. CI cannot see that failure. After
+deploying, confirm against the real listener rather than localhost:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -H 'Host: 192.168.86.20:18201' \
+  -H 'Authorization: Bearer <token>' \
+  http://192.168.86.20:18201/mcp
+```
+
+Expect `200`. A `421` means the bind host regressed. See
+`tests/test_transport_host.py`, which pins this.
+
 ## Troubleshooting
 
 **401 Authorization Error**: Wrong OAuth scopes. You need `activity:read_all`, not just `read`. See the [OAuth Walkthrough](#oauth-walkthrough).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,22 @@ x-logging: &default-logging
 
 services:
   strava-mcp-vault:
-    build: .
-    image: strava-mcp-vault:0.2.0       # explicit version tag, NOT :latest
+    # Pulled from GHCR, published by .github/workflows/release.yml on a
+    # v*.*.* tag. Explicit version, NOT :latest, so a restart can never
+    # silently change the running code. The release workflow refuses to
+    # publish unless this tag matches the git tag being released.
+    #
+    # To build locally instead of pulling:
+    #   docker build -t ghcr.io/pete-builds/strava-mcp-vault:0.3.0 .
+    image: ghcr.io/pete-builds/strava-mcp-vault:0.3.0
     container_name: strava-mcp-vault
     ports:
       - "${MCP_BIND_HOST:-0.0.0.0}:${STRAVA_MCP_PORT:-18201}:18201"
     env_file: .env
     restart: unless-stopped
     read_only: true
+    security_opt:
+      - no-new-privileges:true
     tmpfs:
       - /tmp
     volumes:


### PR DESCRIPTION
Gives this repo the CI publish path it was missing. It was the only MCP server without one.

## The gap

`docker-compose.yml` used `build: .` with a local tag `strava-mcp-vault:0.2.0`, so nix1 built from source on the box. Every other MCP server (mcp-unifi, mcp-phish, mcp-searxng, mcp-spotify, mcp-threatintel) publishes to GHCR on a `v*.*.*` tag and the host pulls a pinned image. There was no way to ship this one through CI.

## What this adds

- **`.github/workflows/release.yml`** following the mcp-phish pattern: multi-arch (`linux/amd64`, `linux/arm64`), SBOM, signed provenance attestation, GHCR push, then a GitHub release. **No new secrets** — GHCR auth is `GITHUB_TOKEN`.
- **`docker-compose.yml`** pulls `ghcr.io/pete-builds/strava-mcp-vault:0.3.0` instead of building, and gains `no-new-privileges` to match mcp-unifi. The version stays explicit rather than `:latest`, so a restart cannot silently change the running code.
- **A release-time guard.** This repo has no `[project]` version in `pyproject.toml`, so the compose tag is the only version surface. The workflow fails if it disagrees with the git tag, which prevents publishing an image the compose does not point at. It parses the YAML key rather than grepping the file, because the surrounding comments also contain an image reference that a text search would happily match instead. Verified both directions: passes at `v0.3.0`, fails at `v0.4.0`.
- **README** documents the release and deploy flow.

## Deploy verification is documented, deliberately

The README tells you to check the real listener after deploying rather than trusting a green pipeline:

```bash
curl -s -o /dev/null -w '%{http_code}\n' -H 'Host: 192.168.86.20:18201' \
  -H 'Authorization: Bearer <token>' http://192.168.86.20:18201/mcp
```

The mcp 2.0 migration in #37 surfaced a failure mode where the server answers `421 Invalid Host header` to every LAN client while all 149 tests pass. CI structurally cannot catch it. `tests/test_transport_host.py` pins it, and this note is the belt to that suspenders.

## Not done here

No tag is pushed, so nothing publishes and nothing on nix1 changes until you cut `v0.3.0`. The first deploy after merging switches the host from building to pulling, which is the one step worth doing while watching.