### PR TITLE
fix(docker): drop pip from the runtime image to clear two Trivy HIGHs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,20 @@ RUN useradd -r -m appuser && \
     mkdir -p /app/data && \
     chown appuser:appuser /app/data
 
+# Drop pip now that the dependencies above are installed. Nothing at runtime
+# uses it: the entrypoint and the healthcheck are plain `python` calls, and the packages
+# themselves are already unpacked into site-packages.
+#
+# This is the only fix for two recurring Trivy HIGHs. pip ships a vendored
+# dependency set (see pip/_vendor/vendor.txt) that Trivy scans as real packages:
+# msgpack 1.1.2 (GHSA-6v7p-g79w-8964) and setuptools 70.3.0 (CVE-2025-47273).
+# Neither is an application dependency, so no lockfile change can move them, and
+# no pip release ships fixed versions. Removing the unused component is the fix.
+RUN python -m pip uninstall -y pip \
+    && rm -rf /usr/local/lib/python3.*/site-packages/pip \
+              /usr/local/lib/python3.*/site-packages/pip-*.dist-info \
+              /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.*
+
 USER appuser
 
 EXPOSE 18201


### PR DESCRIPTION
pip ships a vendored dependency set (`pip/_vendor/vendor.txt`) that Trivy scans as real packages. Two are HIGH with no upstream fix available:

- `msgpack` 1.1.2 — GHSA-6v7p-g79w-8964
- `setuptools` 70.3.0 — CVE-2025-47273

Neither is an application dependency, so no lockfile regeneration moves them and upgrading pip does nothing. Nothing here invokes pip at runtime, so removing it after the install step clears both.

This is the same minimal fix already applied across the rest of the fleet. A multi-stage conversion was piloted and rejected on measurement: it cost +43% image size and bought nothing for images that install pre-built wheels.

### Verified locally against a pre-fix control

```
vendor.txt hits (/usr/local + /venv):  ctrl=2  fixed=0
pip binary in fixed: []
exec positive control: python -V returns normally
imports: server + healthcheck OK
```

The `ctrl=2` is a control image built from current `main`, so the zero is a real zero and not a check that silently matches nothing.

Not deployed. This service runs on nix1 and needs a rebuild after merge to actually clear.

Image size goes from 256MB to 262MB here. That is the layered-filesystem effect: deleting files in a later layer records the deletion without reclaiming the bytes in the layer below. The vulnerable files are genuinely absent from the flattened image, which is what Trivy scans and what a running container sees, confirmed by the zero above.