### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
 
       - name: Enable auto-merge (patch + minor only)
         if: steps.meta.outputs.update-type != 'version-update:semver-major'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,13 +57,13 @@ jobs:
           PYEOF
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -71,7 +71,7 @@ jobs:
 
       - name: Extract version
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -81,7 +81,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -108,6 +108,6 @@ jobs:
       contents: write
     steps:
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           generate_release_notes: true


### PR DESCRIPTION
Pins third-party GitHub Actions to commit SHAs. A tag is mutable, so the upstream
owner can change what runs in CI at any time; a commit SHA cannot move.

The original tag is preserved as a trailing comment so the ref stays readable and
Dependabot can still see which version it is bumping from.

**`.github/workflows/dependabot-auto-merge.yml`**
- `dependabot/fetch-metadata@v3` -> `25dd0e34f4fe...`

**`.github/workflows/release.yml`**
- `docker/setup-qemu-action@v4` -> `96fe6ef7f335...`
- `docker/setup-buildx-action@v3` -> `8d2750c68a42...`
- `docker/login-action@v4` -> `dbcb813823bd...`
- `docker/metadata-action@v6` -> `dc8028041006...`
- `docker/build-push-action@v6` -> `10e90e3645ea...`
- `softprops/action-gh-release@v2` -> `3bb12739c298...`

**7 refs rewritten, 7 distinct (action, tag) pairs.** The fleet drift audit counts the distinct pairs, so its finding count is lower than the number of edits here whenever an action appears more than once. Both are correct.

Opened as a draft by `scripts/pin-actions.py`. First-party `actions/*` refs are
deliberately left on tags.