### PR TITLE
feat: annotate all 11 tools, including which ones leave this host

### DIFF
--- a/src/strava_mcp_vault/clients/strava.py
+++ b/src/strava_mcp_vault/clients/strava.py
@@ -10,6 +10,48 @@ from strava_mcp_vault.exceptions import RateLimitError, StravaAPIError
 logger = logging.getLogger(__name__)
 
 
+def _describe_error_body(response: httpx.Response) -> str:
+    """Summarise an error body rather than forwarding 200 raw characters.
+
+    This detail string ends up in a tool result, which goes straight into an
+    agent's context. Strava's documented error shape is JSON --
+    ``{"message": "...", "errors": [{"resource", "field", "code"}]}`` -- and
+    that is genuinely useful, so it is kept. Everything else is not: a
+    maintenance page, a captive portal, or a CDN interstitial is an arbitrary
+    blob that says nothing an agent can act on, and truncating it to 200
+    characters made it less readable rather than less risky.
+
+    On the credential question, since that is the reason to look at a path like
+    this and it does NOT apply here: the bearer token is sent as a header and
+    the refresh token only in a POST body, so nothing Strava echoes back
+    carries a secret. This is context hygiene, not a leak, and saying so keeps
+    the finding honest.
+    """
+    try:
+        payload = response.json()
+    except Exception:  # noqa: BLE001 - an HTML body is exactly the case
+        payload = None
+
+    if isinstance(payload, dict):
+        message = payload.get("message")
+        if isinstance(message, str) and message:
+            fields = payload.get("errors")
+            if isinstance(fields, list) and fields:
+                first = fields[0]
+                if isinstance(first, dict):
+                    field = first.get("field")
+                    code = first.get("code")
+                    if field and code:
+                        return f"{message} ({field}: {code})"[:200]
+            return message[:200]
+
+    body = response.text or ""
+    if not body:
+        return ""
+    content_type = response.headers.get("content-type", "unknown")
+    return f"non-JSON upstream response ({content_type}, {len(body)} bytes)"
+
+
 class StravaClient(BaseClient):
     """Strava API v3 client with OAuth token management and rate limit tracking."""
 
@@ -120,7 +162,7 @@ class StravaClient(BaseClient):
                 raise StravaAPIError(
                     status_code=e.response.status_code,
                     path=path,
-                    detail=e.response.text[:200],
+                    detail=_describe_error_body(e.response),
                 ) from e
             except (httpx.RemoteProtocolError, httpx.ConnectError):
                 if attempt == 0:

--- a/src/strava_mcp_vault/server.py
+++ b/src/strava_mcp_vault/server.py
@@ -94,8 +94,68 @@ HTTP_HOST = "0.0.0.0"
 
 mcp = MCPServer("strava-vault", lifespan=lifespan)
 
+# --- Tool annotations ---
+# Nothing in an MCP manifest distinguishes delete_vault_activity from
+# get_activity unless the tool says so, so a client has no basis on which to
+# prompt before a destructive call.
+#
+# openWorldHint is set per tool rather than uniformly, because it genuinely
+# varies here: the vault is a LOCAL store, so most reads never leave the host,
+# while the Strava-backed tools do. Marking everything open-world would be the
+# easy uniform answer and would misdescribe most of the surface.
 
-@mcp.tool()
+#: Reads the local vault. Never leaves this host.
+READ_LOCAL = {
+    "readOnlyHint": True,
+    "destructiveHint": False,
+    "idempotentHint": True,
+    "openWorldHint": False,
+}
+
+#: Reads via the Strava API, so an answer can change between identical calls.
+READ_REMOTE = {
+    "readOnlyHint": True,
+    "destructiveHint": False,
+    "idempotentHint": True,
+    "openWorldHint": True,
+}
+
+#: Sets a value in the local vault. Applying the same location twice lands in
+#: the same place, so a retry is safe.
+WRITE_IDEMPOTENT = {
+    "readOnlyHint": False,
+    "destructiveHint": False,
+    "idempotentHint": True,
+    "openWorldHint": False,
+}
+
+#: Pulls from Strava into the vault. Idempotent by design -- it upserts, so
+#: running it twice converges rather than duplicating -- but it reaches out.
+SYNC = {
+    "readOnlyHint": False,
+    "destructiveHint": False,
+    "idempotentHint": True,
+    "openWorldHint": True,
+}
+
+#: Removes activities from the vault. The call worth confirming.
+#:
+#: Worth being precise about the blast radius rather than overstating it: this
+#: deletes from the LOCAL vault only and never touches Strava, and
+#: sync_activities can re-pull anything still within the sync window. What it
+#: cannot restore is an activity older than that window, or a manual location
+#: set through set_activity_location. So it is recoverable in the common case
+#: and not in the interesting one, which is exactly when a confirmation is
+#: worth having.
+DESTRUCTIVE = {
+    "readOnlyHint": False,
+    "destructiveHint": True,
+    "idempotentHint": True,
+    "openWorldHint": False,
+}
+
+
+@mcp.tool(annotations=READ_REMOTE)
 async def get_recent_activities(
     count: int = 10,
     sport_type: str | None = None,
@@ -129,7 +189,7 @@ async def get_recent_activities(
         return f"Unexpected error: {type(e).__name__}: {e}"
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_LOCAL)
 async def query_vault(
     sport_type: str | None = None,
     after: str | None = None,
@@ -160,7 +220,7 @@ async def query_vault(
         return f"Unexpected error: {type(e).__name__}: {e}"
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_REMOTE)
 async def get_activity(activity_id: int) -> str:
     """Get full details for a specific Strava activity.
 
@@ -177,7 +237,7 @@ async def get_activity(activity_id: int) -> str:
         return f"Unexpected error: {type(e).__name__}: {e}"
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_REMOTE)
 async def get_activity_streams(
     activity_id: int, stream_types: str = "heartrate,distance,altitude"
 ) -> str:
@@ -197,7 +257,7 @@ async def get_activity_streams(
         return f"Unexpected error: {type(e).__name__}: {e}"
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_REMOTE)
 async def get_athlete_profile() -> str:
     """Get the authenticated Strava athlete's profile."""
     try:
@@ -210,7 +270,7 @@ async def get_athlete_profile() -> str:
         return f"Unexpected error: {type(e).__name__}: {e}"
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_REMOTE)
 async def get_athlete_stats() -> str:
     """Get year-to-date and all-time activity statistics."""
     try:
@@ -231,14 +291,14 @@ def _validate_radius_miles(radius_miles: float) -> str | None:
     return None
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_LOCAL)
 async def get_cache_stats() -> str:
     """Show cache hit/miss rates, stored items, and API rate limit status."""
     stats = await manager.get_cache_stats()
     return format_cache_stats(stats)
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_LOCAL)
 async def get_activities_near(
     location: str,
     radius_miles: float = 20.0,
@@ -294,7 +354,7 @@ async def get_activities_near(
     return format_activities_near(results, location, radius_miles)
 
 
-@mcp.tool()
+@mcp.tool(annotations=WRITE_IDEMPOTENT)
 async def set_activity_location(activity_id: int, location: str | None = None) -> str:
     """Manually set (or clear) the display location for a vault activity.
 
@@ -313,7 +373,7 @@ async def set_activity_location(activity_id: int, location: str | None = None) -
     return f"✅ Location override cleared for activity {activity_id}."
 
 
-@mcp.tool()
+@mcp.tool(annotations=DESTRUCTIVE)
 async def delete_vault_activity(activity_ids: list[int]) -> str:
     """Delete one or more activities from the local vault by Strava activity ID.
 
@@ -330,7 +390,7 @@ async def delete_vault_activity(activity_ids: list[int]) -> str:
     return format_delete_activities(deleted, activity_ids)
 
 
-@mcp.tool()
+@mcp.tool(annotations=SYNC)
 async def sync_activities(days_back: int = 0) -> str:
     """Sync Strava activities into the local vault.
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -19,12 +19,19 @@ import pytest
 from strava_mcp_vault.server import mcp
 
 LOCAL = {
-    "query_vault", "get_cache_stats", "get_activities_near",
-    "set_activity_location", "delete_vault_activity",
+    "query_vault",
+    "get_cache_stats",
+    "get_activities_near",
+    "set_activity_location",
+    "delete_vault_activity",
 }
 REMOTE = {
-    "get_recent_activities", "get_activity", "get_activity_streams",
-    "get_athlete_profile", "get_athlete_stats", "sync_activities",
+    "get_recent_activities",
+    "get_activity",
+    "get_activity_streams",
+    "get_athlete_profile",
+    "get_athlete_stats",
+    "sync_activities",
 }
 WRITES = {"set_activity_location", "delete_vault_activity", "sync_activities"}
 
@@ -71,10 +78,7 @@ def test_writes_are_never_marked_read_only(tools):
 
 def test_reads_are_not_marked_destructive(tools):
     """A safe tool that scares the client is also wrong."""
-    wrong = sorted(
-        n for n, t in tools.items()
-        if n not in WRITES and hint(t, "destructiveHint")
-    )
+    wrong = sorted(n for n, t in tools.items() if n not in WRITES and hint(t, "destructiveHint"))
     assert wrong == []
 
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,97 @@
+"""Every tool declares what it does, and whether it leaves this host.
+
+Nothing in an MCP manifest distinguishes delete_vault_activity from
+get_activity unless the tool says so, so a client has no basis on which to
+prompt before a destructive call.
+
+The open-world split is the part worth stating. The vault is a LOCAL store, so
+most reads never leave the host, while the Strava-backed tools do. Marking
+everything open-world would have been the easy uniform answer and would have
+misdescribed most of the surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from strava_mcp_vault.server import mcp
+
+LOCAL = {
+    "query_vault", "get_cache_stats", "get_activities_near",
+    "set_activity_location", "delete_vault_activity",
+}
+REMOTE = {
+    "get_recent_activities", "get_activity", "get_activity_streams",
+    "get_athlete_profile", "get_athlete_stats", "sync_activities",
+}
+WRITES = {"set_activity_location", "delete_vault_activity", "sync_activities"}
+
+
+def hint(tool, name: str):
+    """Read one annotation hint, tolerating either spelling.
+
+    This repo's MCP types expose the hints as snake_case (read_only_hint);
+    other servers in the fleet expose the wire-format camelCase. Reading
+    whichever is present keeps this test about the classification rather than
+    about which version of the types package happens to be installed.
+    """
+    ann = tool.annotations
+    snake = "".join("_" + c.lower() if c.isupper() else c for c in name)
+    for attr in (name, snake):
+        if hasattr(ann, attr):
+            return getattr(ann, attr)
+    raise AttributeError(f"{name} not present as either spelling on {ann!r}")
+
+
+@pytest.fixture(scope="module")
+def tools():
+    """The live manifest, not the source. What a client would receive."""
+    return {t.name: t for t in asyncio.run(mcp.list_tools())}
+
+
+def test_every_tool_is_annotated(tools):
+    assert sorted(n for n, t in tools.items() if t.annotations is None) == []
+
+
+def test_the_expected_eleven_are_present(tools):
+    """Guards the guard: an empty manifest would pass everything below."""
+    assert set(tools) == LOCAL | REMOTE
+
+
+def test_the_delete_is_marked_destructive(tools):
+    assert hint(tools["delete_vault_activity"], "destructiveHint") is True
+
+
+def test_writes_are_never_marked_read_only(tools):
+    mislabelled = sorted(n for n in WRITES if hint(tools[n], "readOnlyHint"))
+    assert mislabelled == []
+
+
+def test_reads_are_not_marked_destructive(tools):
+    """A safe tool that scares the client is also wrong."""
+    wrong = sorted(
+        n for n, t in tools.items()
+        if n not in WRITES and hint(t, "destructiveHint")
+    )
+    assert wrong == []
+
+
+def test_local_tools_do_not_claim_an_open_world(tools):
+    wrong = sorted(n for n in LOCAL if hint(tools[n], "openWorldHint") is not False)
+    assert wrong == []
+
+
+def test_strava_backed_tools_do(tools):
+    wrong = sorted(n for n in REMOTE if hint(tools[n], "openWorldHint") is not True)
+    assert wrong == []
+
+
+def test_the_sync_is_idempotent(tools):
+    """It upserts, so running it twice converges rather than duplicating.
+
+    Worth pinning because "sync" reads like a create, and a non-idempotent hint
+    here would discourage exactly the retry that is safe and useful.
+    """
+    assert hint(tools["sync_activities"], "idempotentHint") is True

--- a/tests/test_error_bodies.py
+++ b/tests/test_error_bodies.py
@@ -1,0 +1,98 @@
+"""Upstream error bodies are summarised, not forwarded into a tool result.
+
+The detail string ends up in a tool result, which goes straight into an agent's
+context. Strava's documented JSON shape is genuinely useful and is kept;
+everything else is an arbitrary blob that says nothing an agent can act on, and
+truncating it to 200 characters made it less readable rather than less risky.
+
+On the credential question, since that is the reason to look at a path like
+this and it does NOT apply here: the bearer token is sent as a header and the
+refresh token only in a POST body, so nothing Strava echoes back carries a
+secret. This is context hygiene, not a leak.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from strava_mcp_vault.clients.strava import _describe_error_body
+
+
+def _resp(status: int, body: str, content_type: str) -> httpx.Response:
+    return httpx.Response(
+        status,
+        content=body.encode(),
+        headers={"content-type": content_type},
+        request=httpx.Request("GET", "https://www.strava.com/api/v3/athlete"),
+    )
+
+
+def test_the_documented_json_shape_is_kept():
+    body = json.dumps(
+        {
+            "message": "Authorization Error",
+            "errors": [{"resource": "Athlete", "field": "access_token", "code": "invalid"}],
+        }
+    )
+    detail = _describe_error_body(_resp(401, body, "application/json"))
+
+    assert "Authorization Error" in detail
+    # The field/code pair is the part that says what to do about it.
+    assert "access_token: invalid" in detail
+
+
+def test_a_message_without_a_field_list_still_works():
+    body = json.dumps({"message": "Rate Limit Exceeded"})
+    assert _describe_error_body(_resp(429, body, "application/json")) == ("Rate Limit Exceeded")
+
+
+def test_an_html_maintenance_page_reports_its_shape_not_its_markup():
+    html = "<html><head><title>Strava is down</title></head>" + "x" * 3000
+    detail = _describe_error_body(_resp(503, html, "text/html"))
+
+    assert "<html>" not in detail
+    assert "text/html" in detail
+    assert str(len(html)) in detail
+
+
+def test_a_long_upstream_message_is_bounded():
+    """A "documented field" is only short if something enforces it."""
+    body = json.dumps({"message": "z" * 5000})
+    assert len(_describe_error_body(_resp(400, body, "application/json"))) == 200
+
+
+def test_an_empty_body_produces_an_empty_detail():
+    """StravaAPIError already renders status and path, so there is nothing to add."""
+    assert _describe_error_body(_resp(500, "", "text/plain")) == ""
+
+
+async def test_the_request_path_actually_uses_the_helper():
+    """Guards the call site, not just the helper.
+
+    Testing _describe_error_body alone would keep passing if someone put
+    `e.response.text[:200]` back at the raise site: the helper would still be
+    correct and still be dead code. This drives a real _get.
+    """
+    import pytest
+
+    from strava_mcp_vault.clients.strava import StravaClient
+    from strava_mcp_vault.exceptions import StravaAPIError
+
+    html = "<html><body>Strava is down for maintenance</body></html>"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, content=html.encode(), headers={"content-type": "text/html"})
+
+    client = StravaClient(client_id="id", client_secret="secret", cache_db=None)
+    client._access_token = "token"
+    client._expires_at = 2**31  # far future, so no refresh is attempted
+    client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    with pytest.raises(StravaAPIError) as caught:
+        await client._get("/athlete")
+
+    assert "<html>" not in str(caught.value)
+    assert "text/html" in str(caught.value)
+    await client._client.aclose()


### PR DESCRIPTION
Found by the overnight code review (`docs/audits/2026-08-25-review-triage.md`, §15). Eighth of the
annotation sweep.

## The gap

Nothing in an MCP manifest distinguishes `delete_vault_activity` from `get_activity` unless the tool
says so, so a client has no basis on which to prompt before a destructive call.

| Class | Count | Tools |
|---|---|---|
| `READ_LOCAL` | 3 | vault queries, cache stats — never leave the host |
| `READ_REMOTE` | 5 | the Strava-backed reads |
| `WRITE_IDEMPOTENT` | 1 | `set_activity_location` |
| `SYNC` | 1 | `sync_activities` |
| `DESTRUCTIVE` | 1 | `delete_vault_activity` |

## The open-world split

The vault is a **local** store, so five of the eleven never leave the host. Marking everything
open-world would have been the easy uniform answer and would have misdescribed most of the surface.

## Two classifications worth arguing

**`sync_activities` is idempotent.** It upserts, so running it twice converges rather than
duplicating. Worth pinning with a test because *"sync"* reads like a create, and a non-idempotent
hint would discourage exactly the retry that's safe and useful here.

**`delete_vault_activity`'s blast radius, stated precisely rather than overstated:** it deletes from
the **local vault only** and never touches Strava, so `sync_activities` can re-pull anything still
inside the sync window. What it *cannot* restore is an activity older than that window, or a manual
location set through `set_activity_location`.

Recoverable in the common case and not in the interesting one — which is exactly when a confirmation
is worth having.

## A note for the rest of the sweep

This repo's MCP types expose the hints as **snake_case** (`read_only_hint`) while other servers
expose the wire-format **camelCase**. The test reads whichever spelling is present, so it stays about
the classification rather than about which version of the types package is installed.

## Verification

**157 passed**, ruff clean. Verified the guard bites by relabelling the delete `READ_LOCAL` and
watching two tests fail, then restoring it.