### PR TITLE
fix: summarise Strava error bodies instead of forwarding 200 raw characters

### DIFF
--- a/src/strava_mcp_vault/clients/strava.py
+++ b/src/strava_mcp_vault/clients/strava.py
@@ -10,6 +10,48 @@ from strava_mcp_vault.exceptions import RateLimitError, StravaAPIError
 logger = logging.getLogger(__name__)
 
 
+def _describe_error_body(response: httpx.Response) -> str:
+    """Summarise an error body rather than forwarding 200 raw characters.
+
+    This detail string ends up in a tool result, which goes straight into an
+    agent's context. Strava's documented error shape is JSON --
+    ``{"message": "...", "errors": [{"resource", "field", "code"}]}`` -- and
+    that is genuinely useful, so it is kept. Everything else is not: a
+    maintenance page, a captive portal, or a CDN interstitial is an arbitrary
+    blob that says nothing an agent can act on, and truncating it to 200
+    characters made it less readable rather than less risky.
+
+    On the credential question, since that is the reason to look at a path like
+    this and it does NOT apply here: the bearer token is sent as a header and
+    the refresh token only in a POST body, so nothing Strava echoes back
+    carries a secret. This is context hygiene, not a leak, and saying so keeps
+    the finding honest.
+    """
+    try:
+        payload = response.json()
+    except Exception:  # noqa: BLE001 - an HTML body is exactly the case
+        payload = None
+
+    if isinstance(payload, dict):
+        message = payload.get("message")
+        if isinstance(message, str) and message:
+            fields = payload.get("errors")
+            if isinstance(fields, list) and fields:
+                first = fields[0]
+                if isinstance(first, dict):
+                    field = first.get("field")
+                    code = first.get("code")
+                    if field and code:
+                        return f"{message} ({field}: {code})"[:200]
+            return message[:200]
+
+    body = response.text or ""
+    if not body:
+        return ""
+    content_type = response.headers.get("content-type", "unknown")
+    return f"non-JSON upstream response ({content_type}, {len(body)} bytes)"
+
+
 class StravaClient(BaseClient):
     """Strava API v3 client with OAuth token management and rate limit tracking."""
 
@@ -120,7 +162,7 @@ class StravaClient(BaseClient):
                 raise StravaAPIError(
                     status_code=e.response.status_code,
                     path=path,
-                    detail=e.response.text[:200],
+                    detail=_describe_error_body(e.response),
                 ) from e
             except (httpx.RemoteProtocolError, httpx.ConnectError):
                 if attempt == 0:

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -19,12 +19,19 @@ import pytest
 from strava_mcp_vault.server import mcp
 
 LOCAL = {
-    "query_vault", "get_cache_stats", "get_activities_near",
-    "set_activity_location", "delete_vault_activity",
+    "query_vault",
+    "get_cache_stats",
+    "get_activities_near",
+    "set_activity_location",
+    "delete_vault_activity",
 }
 REMOTE = {
-    "get_recent_activities", "get_activity", "get_activity_streams",
-    "get_athlete_profile", "get_athlete_stats", "sync_activities",
+    "get_recent_activities",
+    "get_activity",
+    "get_activity_streams",
+    "get_athlete_profile",
+    "get_athlete_stats",
+    "sync_activities",
 }
 WRITES = {"set_activity_location", "delete_vault_activity", "sync_activities"}
 
@@ -71,10 +78,7 @@ def test_writes_are_never_marked_read_only(tools):
 
 def test_reads_are_not_marked_destructive(tools):
     """A safe tool that scares the client is also wrong."""
-    wrong = sorted(
-        n for n, t in tools.items()
-        if n not in WRITES and hint(t, "destructiveHint")
-    )
+    wrong = sorted(n for n, t in tools.items() if n not in WRITES and hint(t, "destructiveHint"))
     assert wrong == []
 
 

--- a/tests/test_error_bodies.py
+++ b/tests/test_error_bodies.py
@@ -1,0 +1,99 @@
+"""Upstream error bodies are summarised, not forwarded into a tool result.
+
+The detail string ends up in a tool result, which goes straight into an agent's
+context. Strava's documented JSON shape is genuinely useful and is kept;
+everything else is an arbitrary blob that says nothing an agent can act on, and
+truncating it to 200 characters made it less readable rather than less risky.
+
+On the credential question, since that is the reason to look at a path like
+this and it does NOT apply here: the bearer token is sent as a header and the
+refresh token only in a POST body, so nothing Strava echoes back carries a
+secret. This is context hygiene, not a leak.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from strava_mcp_vault.clients.strava import _describe_error_body
+
+
+def _resp(status: int, body: str, content_type: str) -> httpx.Response:
+    return httpx.Response(
+        status,
+        content=body.encode(),
+        headers={"content-type": content_type},
+        request=httpx.Request("GET", "https://www.strava.com/api/v3/athlete"),
+    )
+
+
+def test_the_documented_json_shape_is_kept():
+    body = json.dumps({
+        "message": "Authorization Error",
+        "errors": [{"resource": "Athlete", "field": "access_token", "code": "invalid"}],
+    })
+    detail = _describe_error_body(_resp(401, body, "application/json"))
+
+    assert "Authorization Error" in detail
+    # The field/code pair is the part that says what to do about it.
+    assert "access_token: invalid" in detail
+
+
+def test_a_message_without_a_field_list_still_works():
+    body = json.dumps({"message": "Rate Limit Exceeded"})
+    assert _describe_error_body(_resp(429, body, "application/json")) == (
+        "Rate Limit Exceeded"
+    )
+
+
+def test_an_html_maintenance_page_reports_its_shape_not_its_markup():
+    html = "<html><head><title>Strava is down</title></head>" + "x" * 3000
+    detail = _describe_error_body(_resp(503, html, "text/html"))
+
+    assert "<html>" not in detail
+    assert "text/html" in detail
+    assert str(len(html)) in detail
+
+
+def test_a_long_upstream_message_is_bounded():
+    """A "documented field" is only short if something enforces it."""
+    body = json.dumps({"message": "z" * 5000})
+    assert len(_describe_error_body(_resp(400, body, "application/json"))) == 200
+
+
+def test_an_empty_body_produces_an_empty_detail():
+    """StravaAPIError already renders status and path, so there is nothing to add."""
+    assert _describe_error_body(_resp(500, "", "text/plain")) == ""
+
+
+async def test_the_request_path_actually_uses_the_helper():
+    """Guards the call site, not just the helper.
+
+    Testing _describe_error_body alone would keep passing if someone put
+    `e.response.text[:200]` back at the raise site: the helper would still be
+    correct and still be dead code. This drives a real _get.
+    """
+    import pytest
+
+    from strava_mcp_vault.clients.strava import StravaClient
+    from strava_mcp_vault.exceptions import StravaAPIError
+
+    html = "<html><body>Strava is down for maintenance</body></html>"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, content=html.encode(),
+                              headers={"content-type": "text/html"})
+
+    client = StravaClient(client_id="id", client_secret="secret", cache_db=None)
+    client._access_token = "token"
+    client._expires_at = 2**31  # far future, so no refresh is attempted
+    client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    with pytest.raises(StravaAPIError) as caught:
+        await client._get("/athlete")
+
+    assert "<html>" not in str(caught.value)
+    assert "text/html" in str(caught.value)
+    await client._client.aclose()

--- a/tests/test_error_bodies.py
+++ b/tests/test_error_bodies.py
@@ -30,10 +30,12 @@ def _resp(status: int, body: str, content_type: str) -> httpx.Response:
 
 
 def test_the_documented_json_shape_is_kept():
-    body = json.dumps({
-        "message": "Authorization Error",
-        "errors": [{"resource": "Athlete", "field": "access_token", "code": "invalid"}],
-    })
+    body = json.dumps(
+        {
+            "message": "Authorization Error",
+            "errors": [{"resource": "Athlete", "field": "access_token", "code": "invalid"}],
+        }
+    )
     detail = _describe_error_body(_resp(401, body, "application/json"))
 
     assert "Authorization Error" in detail
@@ -43,9 +45,7 @@ def test_the_documented_json_shape_is_kept():
 
 def test_a_message_without_a_field_list_still_works():
     body = json.dumps({"message": "Rate Limit Exceeded"})
-    assert _describe_error_body(_resp(429, body, "application/json")) == (
-        "Rate Limit Exceeded"
-    )
+    assert _describe_error_body(_resp(429, body, "application/json")) == ("Rate Limit Exceeded")
 
 
 def test_an_html_maintenance_page_reports_its_shape_not_its_markup():
@@ -83,8 +83,7 @@ async def test_the_request_path_actually_uses_the_helper():
     html = "<html><body>Strava is down for maintenance</body></html>"
 
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(503, content=html.encode(),
-                              headers={"content-type": "text/html"})
+        return httpx.Response(503, content=html.encode(), headers={"content-type": "text/html"})
 
     client = StravaClient(client_id="id", client_secret="secret", cache_db=None)
     client._access_token = "token"


### PR DESCRIPTION
Found by the overnight code review (`docs/audits/2026-08-25-code-review-extra-passes.md`, pattern 2).
Fourth of six servers.

> Stacked on `#45` (`feat/tool-annotations`). Review that first.

## The change

The `detail` string ends up in a tool result, which goes **straight into an agent's context**.

Strava's documented error shape is JSON — `{"message": ..., "errors": [{"resource", "field",
"code"}]}` — and that's genuinely useful, so it's kept, including the field/code pair that says what
to do about the failure.

Everything else is an arbitrary blob: a maintenance page, a captive portal, a CDN interstitial.
Truncating one of those to 200 characters made it **less readable rather than less risky**.

## What this is *not*

The credential question is the reason to look at a path like this, and **it doesn't apply here**: the
bearer token is sent as a header and the refresh token only in a POST body, so nothing Strava echoes
back carries a secret.

This is context hygiene, not a leak. Saying so keeps the finding honest.

## A note on the tests, because the first draft was weaker than it looked

They exercised `_describe_error_body` **directly** — so reverting the *raise site* back to
`e.response.text[:200]` left every one of them passing. The helper would still be correct, and merely
**dead**.

Caught by trying exactly that revert. A sixth test now drives a real `_get` through a mock transport,
and that one does fail.

## Verification

**163 passed**, 6 added, ruff clean. The bound is enforced, not assumed: a test pins that a
5000-character upstream message truncates to exactly 200.